### PR TITLE
internet-api: URL-decode blob file name when creating BlobClient

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Api/Controllers/TransferController.cs
+++ b/internet-webapp/MediaLibrary.Internet.Api/Controllers/TransferController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Web;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -109,11 +110,11 @@ namespace MediaLibrary.Internet.Api.Controllers
             }
 
             var blobUriBuilder = new BlobUriBuilder(new Uri(entity.FileURL));
-            BlobClient blobClient = blobContainerClient.GetBlobClient(blobUriBuilder.BlobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(HttpUtility.UrlDecode(blobUriBuilder.BlobName));
             await blobClient.DeleteIfExistsAsync();
 
             blobUriBuilder = new BlobUriBuilder(new Uri(entity.ThumbnailURL));
-            blobClient = blobContainerClient.GetBlobClient(blobUriBuilder.BlobName);
+            blobClient = blobContainerClient.GetBlobClient(HttpUtility.UrlDecode(blobUriBuilder.BlobName));
             await blobClient.DeleteIfExistsAsync();
 
             TableOperation deleteOperation = TableOperation.Delete(entity);
@@ -141,7 +142,7 @@ namespace MediaLibrary.Internet.Api.Controllers
 
             // Authenticate with storage and download image via URL
             var blobUriBuilder = new BlobUriBuilder(new Uri(parms.Path));
-            BlobClient blobClient = new BlobClient(storageConnectionString, containerName, blobUriBuilder.BlobName);
+            BlobClient blobClient = new BlobClient(storageConnectionString, containerName, HttpUtility.UrlDecode(blobUriBuilder.BlobName));
             try
             {
                 BlobDownloadInfo download = await blobClient.DownloadAsync();


### PR DESCRIPTION
Fixes 404 error when retrieving file whose name containing spaces due to doing percent-encoding twice