### PR TITLE
build: Add browserslist configuration

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Web/package-lock.json
+++ b/internet-webapp/MediaLibrary.Internet.Web/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001269",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
-      "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "dev": true
     },
     "chalk": {

--- a/internet-webapp/MediaLibrary.Internet.Web/package.json
+++ b/internet-webapp/MediaLibrary.Internet.Web/package.json
@@ -12,6 +12,16 @@
   "keywords": [],
   "author": "uraisg",
   "license": "MIT",
+  "browserslist": [
+    "last 3 chrome versions",
+    "last 3 edge versions",
+    "last 3 firefox versions",
+    "last 3 opera versions",
+    "last 3 safari versions",
+    "last 3 chromeandroid versions",
+    "last 3 firefoxandroid versions",
+    "last 2 iOS major versions"
+  ],
   "devDependencies": {
     "bootstrap": "^4.6.0",
     "laravel-mix": "^6.0.34",

--- a/intranet-webapp/MediaLibrary.Intranet.Web/package-lock.json
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/package-lock.json
@@ -4027,9 +4027,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001269",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
-      "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "dev": true
     },
     "chalk": {

--- a/intranet-webapp/MediaLibrary.Intranet.Web/package.json
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/package.json
@@ -12,6 +12,16 @@
   "keywords": [],
   "author": "uraisg",
   "license": "MIT",
+  "browserslist": [
+    "last 3 chrome versions",
+    "last 3 edge versions",
+    "last 3 firefox versions",
+    "last 3 opera versions",
+    "last 3 safari versions",
+    "last 3 chromeandroid versions",
+    "last 3 firefoxandroid versions",
+    "last 2 iOS major versions"
+  ],
   "devDependencies": {
     "@babel/preset-react": "^7.12.10",
     "bootstrap": "^4.6.0",


### PR DESCRIPTION
Define target browsers that we wish to support, which will be picked up by tools like Babel and autoprefixer.

- Chrome
- Edge
- Firefox
- Opera
- Safari
- Chrome for Android
- Firefox for Android
- iOS Safari
