### PR TITLE
feat(iz): Allow admin users to be defined in configuration

### DIFF
--- a/intranet-webapp/MediaLibrary.Intranet.Web/AppSettings.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/AppSettings.cs
@@ -13,5 +13,6 @@
         public string SearchIndexName { get; set; }
         public string ApiDomain { get; set; }
         public string ApiKey { get; set; }
+        public string AdminUsers { get; set; }
     }
 }

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Configuration/Authentication/UserRoleClaimsTransformation.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Configuration/Authentication/UserRoleClaimsTransformation.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using MediaLibrary.Intranet.Web.Common;
+using MediaLibrary.Intranet.Web.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace MediaLibrary.Intranet.Web.Configuration
+{
+    /// <summary>
+    /// UserRoleClaimsTransformation checks if the ClaimsPrincipal represents a normal or an admin
+    /// user and adds it as a Role claim. 
+    /// </summary>
+    class UserRoleClaimsTransformation : IClaimsTransformation
+    {
+        private readonly IEnumerable<string> _adminUsers;
+        private bool _hasTransformed = false;
+
+        public UserRoleClaimsTransformation(IOptions<AppSettings> appSettings)
+        {
+            var adminUsersStr = appSettings.Value.AdminUsers;
+            _adminUsers = string.IsNullOrEmpty(adminUsersStr)
+                ? Enumerable.Empty<string>()
+                : adminUsersStr.Split(',').Select(x => x.Trim()).ToHashSet();
+        }
+        public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+        {
+            if (!_hasTransformed)
+            {
+                _hasTransformed = true;
+
+                // Check if user's email address is in list of admins
+                string role = _adminUsers.Contains(principal.GetUserGraphEmail())
+                    ? UserRole.Admin
+                    : UserRole.User;
+                var ci = new ClaimsIdentity();
+                ci.AddClaim(new Claim(ClaimTypes.Role, role));
+                principal.AddIdentity(ci);
+            }
+
+            return Task.FromResult(principal);
+        }
+    }
+}

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Models/UserRole.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Models/UserRole.cs
@@ -1,0 +1,8 @@
+﻿namespace MediaLibrary.Intranet.Web.Models
+{
+    public static class UserRole
+    {
+        public const string Admin = "Admin";
+        public const string User = "User";
+    }
+}

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Startup.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Startup.cs
@@ -2,6 +2,7 @@
 using MediaLibrary.Intranet.Web.Common;
 using MediaLibrary.Intranet.Web.Configuration;
 using MediaLibrary.Intranet.Web.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -44,6 +45,7 @@ namespace MediaLibrary.Intranet.Web
             });
             services.AddCustomMvcConfig();
 
+            services.AddScoped<IClaimsTransformation, UserRoleClaimsTransformation>();
             services.AddOptions<AppSettings>().Bind(Configuration.GetSection("AppSettings"));
             services.AddHttpClient();
             services.AddHostedService<ScheduledService>();

--- a/intranet-webapp/MediaLibrary.Intranet.Web/appsettings.sample.json
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/appsettings.sample.json
@@ -16,7 +16,8 @@
     "SearchServiceQueryApiKey": "{SearchServiceQueryApiKey}",
     "SearchIndexName": "{SearchIndexName}",
     "ApiDomain": "https://{internetapibase}/",
-    "ApiKey": "apipassword"
+    "ApiKey": "apipassword",
+    "AdminUsers": "foo@example.com, bar@example.org"
   },
   "Hosting": {
     "PathBase": "",


### PR DESCRIPTION
Add new property to AppSettings to define a list of admin users. Create
`UserRoleClaimsTransformation` to set user role claim based on whether
the user appears in the admin user list. Register it as a scoped
service so that it only initializes once per request.