### PR TITLE
fix(iz): Sort planning areas alphabetically, and group them by region

### DIFF
--- a/intranet-webapp/MediaLibrary.Intranet.Web/Common/GeoSearchHelper.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Common/GeoSearchHelper.cs
@@ -7,10 +7,12 @@ namespace MediaLibrary.Intranet.Web.Common
     public class GeoSearchHelper : IGeoSearchHelper
     {
         private readonly Dictionary<string, AreaPolygon> _dictionary; // key = name, value = WKT string for search boundary
+        private readonly List<PlanningRegion> _regions;
 
         public GeoSearchHelper()
         {
             _dictionary = LoadData("planning-area-boundary.json");
+            _regions = GroupRegions(_dictionary);
         }
 
         private static Dictionary<string, AreaPolygon> LoadData(string path)
@@ -32,6 +34,7 @@ namespace MediaLibrary.Intranet.Web.Common
                 {
                     Id = feature.properties.PLN_AREA_C,
                     Name = feature.properties.PLN_AREA_N,
+                    Region = feature.properties.CA_IND == "Y" ? "CENTRAL AREA" : feature.properties.REGION_N,
                     WktPolygon = wkt
                 });
             }
@@ -39,9 +42,28 @@ namespace MediaLibrary.Intranet.Web.Common
             return result;
         }
 
-        public Dictionary<string, AreaPolygon> GetDictionary()
+        private static List<PlanningRegion> GroupRegions(Dictionary<string, AreaPolygon> dictionary)
         {
-            return _dictionary;
+            var areasByRegion = dictionary.Values
+                .OrderBy(s => s.Region)
+                .ThenBy(s => s.Name)
+                .GroupBy(s => s.Region, (region, areas) => new PlanningRegion()
+                {
+                    Region = region,
+                    Areas = areas.Select(s => new PlanningArea() { Id = s.Id, Name = s.Name }).ToList().AsReadOnly()
+                });
+
+            return areasByRegion.ToList();
+        }
+
+        public bool TryGetPolygonFromId(string id, out AreaPolygon areaPolygon)
+        {
+            return _dictionary.TryGetValue(id, out areaPolygon);
+        }
+
+        public IList<PlanningRegion> GetRegions()
+        {
+            return _regions.AsReadOnly();
         }
     }
 }

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Common/IGeoSearchHelper.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Common/IGeoSearchHelper.cs
@@ -4,13 +4,43 @@ namespace MediaLibrary.Intranet.Web.Common
 {
     public interface IGeoSearchHelper
     {
-        Dictionary<string, AreaPolygon> GetDictionary();
+        /// <summary>
+        /// Attempts to get the AreaPolygon associated with the specified id.
+        /// </summary>
+        /// <param name="id">The id of the AreaPolygon to get</param>
+        /// <param name="areaPolygon">
+        /// When this method returns, contains the AreaPolygon associated with the specified id if it exists, or <see langword="null" /> is it cannot be found.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the AreaPolygon is found; <see langword="false"/> otherwise.
+        /// </returns>
+        bool TryGetPolygonFromId(string id, out AreaPolygon areaPolygon);
+
+        /// <summary>
+        /// Returns the list of PlanningRegion.
+        /// </summary>
+        /// <returns>List of PlanningRegion.</returns>
+        IList<PlanningRegion> GetRegions();
     }
 
-    public class AreaPolygon
+    public struct AreaPolygon
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public string Region { get; set; }
         public string WktPolygon { get; set; }
+    }
+
+    public struct PlanningArea
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public struct PlanningRegion
+    {
+        public string Region { get; set; }
+
+        public IReadOnlyList<PlanningArea> Areas { get; set; }
     }
 }

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Controllers/WebApiController.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Controllers/WebApiController.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Identity;
@@ -25,6 +23,7 @@ namespace MediaLibrary.Intranet.Web.Controllers
         private readonly ILogger<WebApiController> _logger;
         private readonly MediaSearchService _mediaSearchService;
         private readonly ItemService _itemService;
+        private readonly IGeoSearchHelper _geoSearchHelper;
 
         private static BlobContainerClient _blobContainerClient = null;
 
@@ -32,12 +31,14 @@ namespace MediaLibrary.Intranet.Web.Controllers
             IOptions<AppSettings> appSettings,
             ILogger<WebApiController> logger,
             MediaSearchService mediaSearchService,
-            ItemService itemService)
+            ItemService itemService,
+            IGeoSearchHelper geoSearchHelper)
         {
             _appSettings = appSettings.Value;
             _logger = logger;
             _mediaSearchService = mediaSearchService;
             _itemService = itemService;
+            _geoSearchHelper = geoSearchHelper;
 
             InitStorage();
         }
@@ -180,9 +181,7 @@ namespace MediaLibrary.Intranet.Web.Controllers
         [HttpGet("/api/areas", Name = nameof(GetAreas))]
         public IActionResult GetAreas()
         {
-            var areas = _mediaSearchService.GetSpatialAreas().Select(s => new { Id = s.Id, Name = s.Name });
-
-            return Ok(areas);
+            return Ok(_geoSearchHelper.GetRegions());
         }
     }
 }

--- a/intranet-webapp/MediaLibrary.Intranet.Web/Services/MediaSearchService.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Services/MediaSearchService.cs
@@ -157,19 +157,12 @@ namespace MediaLibrary.Intranet.Web.Services
                 return null;
             }
 
-            _geoSearchHelper.GetDictionary().TryGetValue(spatialFilter, out var ret);
-
-            if (ret == null)
+            if (!_geoSearchHelper.TryGetPolygonFromId(spatialFilter, out var ret))
             {
                 throw new ArgumentException("Could not find coordinates for given area");
             }
 
             return "geo.intersects(Location, geography'" + ret.WktPolygon + "')";
-        }
-
-        public IList<AreaPolygon> GetSpatialAreas()
-        {
-            return _geoSearchHelper.GetDictionary().Values.ToList();
         }
     }
 }

--- a/intranet-webapp/MediaLibrary.Intranet.Web/assets/scripts/gallery/components/SpatialFilter.js
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/assets/scripts/gallery/components/SpatialFilter.js
@@ -106,17 +106,25 @@ const SpatialFilter = ({ filters, setFilters, areas }) => {
     } else if (type === SpatialFilters.Postal) {
       text += postalCode
     } else if (type === SpatialFilters.Area) {
-      text += areas.find((a) => a.Id == areaName)?.Name || areaName
+      text += areas.flatMap((r) => r.Areas).find((a) => a.Id == areaName)?.Name || areaName
     }
 
     return text
   }
 
-  const areasOptions = areas.map((area) => (
-    <option key={area.Id} value={area.Id}>
-      {area.Name}
-    </option>
-  ))
+  const areasOptions = areas.map((region) => {
+    const options = region.Areas.map((area) => (
+      <option key={area.Id} value={area.Id}>
+        {area.Name}
+      </option>
+    ))
+
+    return (
+      <optgroup label={region.Region}>
+        {options}
+      </optgroup>
+    )
+  })
 
   return (
     <StyledDropdown show={show} onToggle={handleToggle}>


### PR DESCRIPTION
This fixes the issue of planning areas appearing unsorted in location filter dropdown list.

Screenshot of dropdown list with this PR:
![image](https://user-images.githubusercontent.com/4019650/159859687-59edab2a-040a-48b6-8b0d-916120ded9f4.png)
