### PR TITLE
fix(iz): Remove MediaStorageConnectionStringImage configuration variable

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Web/AppSettings.cs
+++ b/internet-webapp/MediaLibrary.Internet.Web/AppSettings.cs
@@ -4,7 +4,6 @@
     {
         public string MediaStorageConnectionString { get; set; }
         public string MediaStorageContainer { get; set; }
-        public string MediaStorageConnectionStringImage { get; set; }
         public string TableConnectionString { get; set; }
         public string TableName { get; set; }
         public string ComputerVisionEndpoint { get; set; }

--- a/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
+++ b/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
@@ -457,7 +457,7 @@ namespace MediaLibrary.Internet.Web.Controllers
             {
                 if (!string.IsNullOrEmpty(_appSettings.MediaStorageConnectionString))
                 {
-                    _blobContainerClient = new BlobContainerClient(_appSettings.MediaStorageConnectionStringImage, _appSettings.MediaStorageContainer);
+                    _blobContainerClient = new BlobContainerClient(_appSettings.MediaStorageConnectionString, _appSettings.MediaStorageContainer);
                 }
                 else
                 {


### PR DESCRIPTION
This variable was introduced in PR #117, but actually has the same purpose as MediaStorageConnectionString. Remove the property from AppSettings class and remove all usages.