### PR TITLE
fix(ez): Allow large image (up to 40MB) to be uploaded

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
+++ b/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
@@ -108,6 +108,7 @@ namespace MediaLibrary.Internet.Web.Controllers
 
         // Adding images to a draft
         [HttpPost("draft/{rowkey}/addImage")]
+        [RequestSizeLimit(42_000_000)]
         public async Task<JsonResult> AddImage([FromForm]AddImageModel req, string rowKey, CancellationToken cancellationToken)
         {
             if (await CheckIfDraftIsEmpty_N_UserMatchDraft(rowKey, true) == false)

--- a/internet-webapp/MediaLibrary.Internet.Web/web.config
+++ b/internet-webapp/MediaLibrary.Internet.Web/web.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+      <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" />
+      <security>
+        <requestFiltering>
+          <!-- Handle requests up to approximately 40.05 MB -->
+          <requestLimits maxAllowedContentLength="42000000" />
+        </requestFiltering>
+      </security>
+    </system.webServer>
+  </location>
+</configuration>


### PR DESCRIPTION
- Configure IIS to allow requests up to 40MB in length
- Override request size limit for AddImage action