### PR TITLE
fix(ez): Resolve display errors in DisplayItem

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Web/assets/scripts/UploadPortal/components/DisplayItem.js
+++ b/internet-webapp/MediaLibrary.Internet.Web/assets/scripts/UploadPortal/components/DisplayItem.js
@@ -81,13 +81,7 @@ const DisplayItem = (props) => {
                 </div>
 
                 <div className="col-8">
-                  {props.item.Location !== 'null' ? (
-                    <PopupMap
-                      coordinates={JSON.parse(props.item.Location).coordinates}
-                    />
-                  ) : (
-                    'No geotag'
-                  )}
+                  {props.item.LocationName}
                 </div>
               </div>
               <div className="py-1 row">
@@ -103,7 +97,13 @@ const DisplayItem = (props) => {
                   <strong>Planning Area:</strong>
                 </div>
                 <div className="col-8">
-                  {props.item.LocationName}
+                  {props.item.Location !== 'null' ? (
+                    <PopupMap
+                      coordinates={JSON.parse(props.item.Location).coordinates}
+                    />
+                  ) : (
+                    'No geotag'
+                  )}
                 </div>
               </div>
               <div className="py-1 row">

--- a/internet-webapp/MediaLibrary.Internet.Web/assets/scripts/UploadPortal/components/DisplayItem.js
+++ b/internet-webapp/MediaLibrary.Internet.Web/assets/scripts/UploadPortal/components/DisplayItem.js
@@ -94,20 +94,6 @@ const DisplayItem = (props) => {
               </div>
               <div className="py-1 row">
                 <div className="col-4">
-                  <strong>Planning Area:</strong>
-                </div>
-                <div className="col-8">
-                  {props.item.Location !== 'null' ? (
-                    <PopupMap
-                      coordinates={JSON.parse(props.item.Location).coordinates}
-                    />
-                  ) : (
-                    'No geotag'
-                  )}
-                </div>
-              </div>
-              <div className="py-1 row">
-                <div className="col-4">
                   <strong>Caption:</strong>
                 </div>
                 <div className="col-8">
@@ -129,6 +115,20 @@ const DisplayItem = (props) => {
                       ))}
                     </div>
                     }
+                </div>
+              </div>
+              <div className="py-1 row">
+                <div className="col-4">
+                  <strong>Geotag:</strong>
+                </div>
+                <div className="col-8">
+                  {props.item.Location !== 'null' ? (
+                    <PopupMap
+                      coordinates={JSON.parse(props.item.Location).coordinates}
+                    />
+                  ) : (
+                    'No geotag'
+                  )}
                 </div>
               </div>
               <div className="py-1 row">


### PR DESCRIPTION
Fix visual errors in `DisplayItem`:

- Labels for geotag (GPS location) and location are incorrect
- Should not use Planning Area to label geotag
- Group geotag with other read-only image info at end of list

![image](https://user-images.githubusercontent.com/4019650/209090347-bfbd4d7b-41ae-492c-8d72-b5e00b9fe245.png)
