### PR TITLE
build(deps): bump Microsoft.Azure.CognitiveServices.Vision.ComputerVision from 5.0.0 to 7.0.1

### DIFF
--- a/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
+++ b/internet-webapp/MediaLibrary.Internet.Web/Controllers/DraftController.cs
@@ -953,7 +953,7 @@ namespace MediaLibrary.Internet.Web.Controllers
             string width = appSettings.ThumbWidth;
             string height = appSettings.ThumbHeight;
 
-            string uriBase = endpoint + "/vision/v3.0/generateThumbnail";
+            string uriBase = endpoint + "/vision/v3.2/generateThumbnail";
 
             HttpClient client = new HttpClient();
             client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
@@ -993,7 +993,7 @@ namespace MediaLibrary.Internet.Web.Controllers
                 Endpoint = endpoint
             };
 
-            List<VisualFeatureTypes> features = new List<VisualFeatureTypes>()
+            List<VisualFeatureTypes?> features = new List<VisualFeatureTypes?>()
                 { VisualFeatureTypes.Tags, VisualFeatureTypes.Description};
 
             ImageAnalysis results = await client.AnalyzeImageInStreamAsync(image, features);

--- a/internet-webapp/MediaLibrary.Internet.Web/MediaLibrary.Internet.Web.csproj
+++ b/internet-webapp/MediaLibrary.Internet.Web/MediaLibrary.Internet.Web.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="12.2.2" />
     <PackageReference Include="MetadataExtractor" Version="2.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.12" allowedVersions="[6,7)" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.18.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="1.18.0" />


### PR DESCRIPTION
The new version uses v3.2 of the Computer Vision API, which at first glance provides better quality tags and captions compared to v3.0.