### PR TITLE
fix: skip port comparison when HttpRequest.Host.Port is null

### DIFF
--- a/intranet-webapp/MediaLibrary.Intranet.Web/Common/ValidateReferrerAttribute.cs
+++ b/intranet-webapp/MediaLibrary.Intranet.Web/Common/ValidateReferrerAttribute.cs
@@ -43,7 +43,8 @@ public class ValidateOriginAttribute : Attribute, IAuthorizationFilter
         }
 
         // Compare the source against the expected target origin in Host header
-        if (!context.HttpContext.Request.Host.Equals(HostString.FromUriComponent(sourceUri)))
+        if (string.Equals(context.HttpContext.Request.Host.Host, sourceUri.Host, StringComparison.OrdinalIgnoreCase) &&
+            (context.HttpContext.Request.Host.Port != null && context.HttpContext.Request.Host.Port != sourceUri.Port))
         {
             // Origins are not matching so we block the request
             context.Result = new StatusCodeResult(StatusCodes.Status403Forbidden);


### PR DESCRIPTION
HttpRequest.Host.Port may sometimes be `null`. If so, do not compare port number against Origin/Referrer header.